### PR TITLE
6주차 STEP12

### DIFF
--- a/src/main/java/io/hhplus/concert/application/payment/UserPaymentComponent.java
+++ b/src/main/java/io/hhplus/concert/application/payment/UserPaymentComponent.java
@@ -1,0 +1,31 @@
+package io.hhplus.concert.application.payment;
+
+import io.hhplus.concert.domain.concert.dto.SeatPriceInfo;
+import io.hhplus.concert.domain.payment.PaymentService;
+import io.hhplus.concert.domain.payment.Ticket;
+import io.hhplus.concert.domain.user.UserService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserPaymentComponent {
+
+    private final UserService userService;
+    private final PaymentService paymentService;
+
+    @Transactional
+    public List<Ticket> updatePaymentData(Long userId, List<SeatPriceInfo> priceInfos) {
+        Integer totalPrice = 0;
+        for (SeatPriceInfo seatPriceInfo : priceInfos) totalPrice += seatPriceInfo.price();
+
+        userService.consumeBalance(userId, totalPrice);
+        List<Ticket> tickets = paymentService.billing(userId, priceInfos);
+        paymentService.savePaymentHistories(tickets);
+
+        return tickets;
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/payment/UserPaymentFacade.java
+++ b/src/main/java/io/hhplus/concert/application/payment/UserPaymentFacade.java
@@ -1,8 +1,5 @@
 package io.hhplus.concert.application.payment;
 
-import io.hhplus.concert.common.enums.ErrorCode;
-import io.hhplus.concert.common.exception.CustomException;
-import io.hhplus.concert.domain.user.Balance;
 import io.hhplus.concert.domain.user.UserService;
 import io.hhplus.concert.domain.concert.ConcertService;
 import io.hhplus.concert.domain.concert.dto.SeatPriceInfo;
@@ -12,13 +9,11 @@ import io.hhplus.concert.domain.payment.Ticket;
 import io.hhplus.concert.domain.payment.dto.TicketInfo;
 import io.hhplus.concert.domain.token.Token;
 import io.hhplus.concert.domain.token.TokenService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Objects;
 
 @Component
 @Slf4j
@@ -26,16 +21,13 @@ import java.util.Objects;
 public class UserPaymentFacade implements UserPaymentService {
     private final TokenService tokenService;
     private final ConcertService concertService;
+    private final UserPaymentComponent userPaymentComponent;
     private final UserService userService;
     private final PaymentService paymentService;
 
     @Override
-    @Transactional
     public List<TicketInfo> billing(String authorization) {
-        // 토큰으로 사용자 정보 조회
         Token token = tokenService.find(authorization);
-
-        // 사용자 ID로 예약된 예약 건들을 조회
         List<Reservation> reservations = concertService.findUserReservations(token.getUserId());
 
         if (reservations.isEmpty()) {
@@ -43,31 +35,13 @@ public class UserPaymentFacade implements UserPaymentService {
             return List.of();
         }
 
-        // 예약된 좌석들의 가격 정보를 조회
         List<SeatPriceInfo> priceInfos = concertService.findReservationPrice(
                 reservations.stream()
                         .map(Reservation::getSeatId)
                         .toList());
 
-        // 사용자가 결제할 총 금액 계산
-        Integer totalPrice = 0;
-        for (SeatPriceInfo seatPriceInfo : priceInfos) totalPrice += seatPriceInfo.price();
-
-        // 사용자의 잔액 조회
-        Balance userBalance = userService.findBalance(token.getUserId());
-
-
-        // 잔액 예외처리
-        if (Objects.isNull(userBalance)) throw new CustomException(ErrorCode.BALANCE_NOT_EXIST);
-
-        // 사용자 잔액 사용
-        userService.consumeBalance(token.getUserId(), totalPrice);
-
-        // 좌석별 티켓 생성
-        List<Ticket> tickets = paymentService.billing(token.getUserId(), priceInfos);
-
-        // 결제 히스토리 생성
-        paymentService.savePaymentHistories(tickets);
+        // 결제와 관련되어 Transaction으로 묶여야하는 메서드 3개를 하나의 컴포넌트로 묶음
+        List<Ticket> tickets = userPaymentComponent.updatePaymentData(token.getUserId(), priceInfos);
 
         return tickets
                 .stream()

--- a/src/main/java/io/hhplus/concert/application/user/UserBalanceFacade.java
+++ b/src/main/java/io/hhplus/concert/application/user/UserBalanceFacade.java
@@ -6,7 +6,6 @@ import io.hhplus.concert.domain.user.UserService;
 import io.hhplus.concert.domain.user.dto.BalanceInfo;
 import io.hhplus.concert.domain.user.dto.RechargeCommand;
 import io.hhplus.concert.domain.user.dto.SaveBalanceHistoryCommand;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +22,6 @@ public class UserBalanceFacade implements UserBalanceService {
     }
 
     @Override
-    @Transactional
     public BalanceInfo rechargeBalance(Long userId, Integer amount) {
         Balance balance = userService.rechargeBalance(new RechargeCommand(userId, amount));
 

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertService.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertService.java
@@ -13,8 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -60,32 +59,47 @@ public class ConcertService {
      * 좌석 예약 메서드
      *
      * @param seatIdList 좌석테이블 ID 리스트
-     * @return List<Reservation> 예약 성공한 좌석에 대한 예약 리스트
+     * @return LocalDateTime 예약 성공한 시각
      */
     @Transactional
-    public List<Reservation> reserveSeats(List<Long> seatIdList, Long userId) {
-        List<Seat> seats = concertRepository.findSeatByIdIn(seatIdList);
+    public boolean reserveSeats(List<Long> seatIdList) {
+        // 데드락 방지로 좌석 ID를 오름차순 정렬
+        Collections.sort(seatIdList);
 
-        seats = seats.stream()
-                .filter(seat -> seat.getStatus().equals(ReservationStatusType.AVAILABLE))
-                .toList();
+        // 여러 좌석에 동시에 락을 걸지 않고, 하나씩 락을 걸어 상태 확인하고 예외처리 하기 위해 SELECT WHERE IN() 에서 for문으로 변경
+        for (Long seatId : seatIdList) {
+            Seat seat = concertRepository.findSeatByIdWithPessimisticLock(seatId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NO_DATA));
 
-        if (seats.size() != seatIdList.size()) {
-            throw new CustomException(ErrorCode.RESERVATION_CONFLICT);
+            if (!seat.getStatus().equals(ReservationStatusType.AVAILABLE)) {
+                throw new CustomException(ErrorCode.RESERVATION_CONFLICT);
+            }
+
+            seat.reserve();
         }
 
-        List<Reservation> reservationList = new ArrayList<>();
+        return true;
+    }
+
+    /**
+     * 예약 데이터 생성 메서드
+     * @param seatIdList 좌석 상태 변경에 성공한 좌석 ID 리스트
+     * @param userId 예약을 요청한 유저 ID
+     * @return List<Reservation> 예약 내용 리스트
+     */
+    @Transactional
+    public List<Reservation> makeReservation(List<Long> seatIdList, Long userId) {
+        List<Reservation> reservations = new ArrayList<>();
         LocalDateTime reservedAt = LocalDateTime.now();
-
-        for (Seat seat : seats) {
-            seat.setStatus(ReservationStatusType.TEMPORARY);
-
-            Reservation reservation = new Reservation(seat.getId(), userId, reservedAt);
-            reservation = concertRepository.saveReservation(reservation);
-            reservationList.add(reservation);
+        for (Long seatId : seatIdList) {
+            reservations.add(new Reservation(seatId, userId, reservedAt));
         }
 
-        return reservationList;
+        List<Reservation> result = concertRepository.saveReservations(reservations);
+
+        if (reservations.size() != result.size()) throw new CustomException(ErrorCode.RESERVATION_PARTIALLY_FAIL);
+
+        return result;
     }
 
     /**
@@ -118,7 +132,7 @@ public class ConcertService {
         for (Seat seat : temporarilyReservedSeats) {
             List<Reservation> reservations = concertRepository.findReservationBySeatId(seat.getId());
 
-            if (reservations.isEmpty()) continue;
+            if (reservations.isEmpty()) seat.setStatus(ReservationStatusType.AVAILABLE);
 
             for (Reservation reservation : reservations) {
                 if (reservation.getReservedAt().isBefore(reservationLifetime)) {
@@ -127,5 +141,9 @@ public class ConcertService {
                 }
             }
         }
+    }
+
+    public void undoReserveSeat(List<Long> seatIdList) {
+        concertRepository.updateSeatStatusByIdIn(seatIdList, ReservationStatusType.AVAILABLE);
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/user/Balance.java
+++ b/src/main/java/io/hhplus/concert/domain/user/Balance.java
@@ -32,6 +32,15 @@ public class Balance {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Version
+    private int version;
+
+    @PrePersist
+    public void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
     public Balance(Long userId) {
         if (Objects.isNull(userId)) throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT);
 

--- a/src/main/java/io/hhplus/concert/domain/user/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserService.java
@@ -4,6 +4,7 @@ import io.hhplus.concert.common.enums.ErrorCode;
 import io.hhplus.concert.common.exception.CustomException;
 import io.hhplus.concert.domain.user.dto.RechargeCommand;
 import io.hhplus.concert.domain.user.dto.SaveBalanceHistoryCommand;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,13 +20,12 @@ public class UserService {
         return balance;
     }
 
+    @Transactional
     public Balance rechargeBalance(RechargeCommand command) {
         Balance balance = userRepository.findBalanceByUserId(command.userId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_DATA));
 
         balance.recharge(command.amount());
-        userRepository.saveBalance(balance);
-
         return balance;
     }
 

--- a/src/main/java/io/hhplus/concert/infrastructure/concert/SeatJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/concert/SeatJpaRepository.java
@@ -3,11 +3,15 @@ package io.hhplus.concert.infrastructure.concert;
 import io.hhplus.concert.common.enums.ReservationStatusType;
 import io.hhplus.concert.domain.concert.model.Seat;
 import io.hhplus.concert.infrastructure.concert.dto.SeatPriceProjection;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByConcertOptionId(Long concertOptionId);
@@ -21,4 +25,12 @@ public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
             "JOIN ConcertOption co ON s.concertOptionId = co.id " +
             "WHERE s.id IN :ids")
     List<SeatPriceProjection> findSeatsProjectionByIdIn(@Param("ids") List<Long> ids);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Seat s WHERE s.id = :id")
+    Optional<Seat> findSeatByIdWithPessimisticLock(Long id);
+
+    @Modifying
+    @Query("UPDATE Seat s SET s.status = :status WHERE s.id IN :ids")
+    List<Seat> updateStatusByIdIn(List<Long> ids, ReservationStatusType status);
 }

--- a/src/test/java/io/hhplus/concert/concurrency/BalanceConcurrencyTest.java
+++ b/src/test/java/io/hhplus/concert/concurrency/BalanceConcurrencyTest.java
@@ -1,0 +1,70 @@
+package io.hhplus.concert.concurrency;
+
+import io.hhplus.concert.application.user.UserBalanceFacade;
+import io.hhplus.concert.domain.user.Balance;
+import io.hhplus.concert.domain.user.User;
+import io.hhplus.concert.domain.user.UserRepository;
+import io.hhplus.concert.domain.user.dto.BalanceInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+@Slf4j
+public class BalanceConcurrencyTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserBalanceFacade userBalanceFacade;
+
+    @Test
+    public void 잔액충전_테스트() throws InterruptedException {
+        // 테스트를 위한 데이터 생성
+        User u = userRepository.saveUser(new User());
+        Balance b = userRepository.saveBalance(new Balance(u.getId(), 0));
+
+        Long userId = u.getId();
+        Integer amount = 300;
+
+        CountDownLatch latch = new CountDownLatch(10);
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        // 동시성 테스트 시작 - 시작 시간 기록
+        Long startTime = System.currentTimeMillis();
+
+        IntStream.range(0, 10).forEach(i -> {
+            executor.submit(() -> {
+                try {
+                    log.info("잔액 업데이트 요청 - 스레드 : {}", Thread.currentThread().getName());
+
+                    BalanceInfo balanceInfo = userBalanceFacade.rechargeBalance(userId, amount);
+                    log.info("잔액 업데이트 성공 : {}, 업데이트 후 잔액 : {}", Thread.currentThread().getName(), balanceInfo.balance());
+                    atomicInteger.getAndAdd(1);
+                } catch (Exception e) {
+                    log.info("{} - 스레드 : {}", e.getMessage(), Thread.currentThread().getName());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        });
+
+        latch.await();
+
+        // 동시성 테스트 끝 - 결과 기록
+        BalanceInfo result = userBalanceFacade.findUserBalance(userId);
+        log.info("동시성 테스트 종료 - 성공 횟수 : {}, 업데이트 후 잔액 : {}, 소요 시간 : {}ms", atomicInteger, result.balance(), System.currentTimeMillis() - startTime);
+
+        executor.shutdown();
+    }
+}

--- a/src/test/java/io/hhplus/concert/concurrency/ConcertConcurrencyTest.java
+++ b/src/test/java/io/hhplus/concert/concurrency/ConcertConcurrencyTest.java
@@ -1,0 +1,120 @@
+package io.hhplus.concert.concurrency;
+
+import io.hhplus.concert.application.concert.UserConcertFacade;
+import io.hhplus.concert.application.concert.UserConcertService;
+import io.hhplus.concert.application.token.UserTokenService;
+import io.hhplus.concert.application.user.UserBalanceFacade;
+import io.hhplus.concert.domain.concert.ConcertRepository;
+import io.hhplus.concert.domain.concert.model.Concert;
+import io.hhplus.concert.domain.concert.model.ConcertOption;
+import io.hhplus.concert.domain.concert.model.Seat;
+import io.hhplus.concert.domain.user.Balance;
+import io.hhplus.concert.domain.user.User;
+import io.hhplus.concert.domain.user.UserRepository;
+import io.hhplus.concert.domain.user.dto.BalanceInfo;
+import io.hhplus.concert.infrastructure.concert.ConcertJpaRepository;
+import io.hhplus.concert.infrastructure.concert.ConcertOptionJpaRepository;
+import io.hhplus.concert.infrastructure.concert.SeatJpaRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+@Slf4j
+public class ConcertConcurrencyTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private SeatJpaRepository seatJpaRepository;
+
+    @Autowired
+    private ConcertOptionJpaRepository concertOptionJpaRepository;
+
+    @Autowired
+    private UserConcertFacade userConcertService;
+
+    @Autowired
+    private UserTokenService userTokenService;
+
+    @Test
+    @DisplayName("좌석 예매가 동시에 들어오는 경우")
+    public void 콘서트예매_동시성_테스트() throws InterruptedException {
+        // 테스트를 위한 데이터 생성
+        User user = userRepository.saveUser(new User());
+        String token = userTokenService.issueUserToken(user.getId()).token();
+
+        Concert concert = concertJpaRepository.save(new Concert("동시성테스트"));
+
+        ConcertOption option = new ConcertOption(null, concert, 10000, 10, LocalDateTime.now(), LocalDateTime.now().plusDays(10));
+        option = concertOptionJpaRepository.save(option);
+
+        List<Long> seats = new ArrayList<>();
+        for (int i = 1; i <= 50; i++) {
+            Seat seat = seatJpaRepository.save(new Seat(option.getId(), i));
+            seats.add(seat.getId());
+        }
+
+        CountDownLatch latch = new CountDownLatch(50);
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+
+        // 동시성 테스트 시작 - 시작 시간 기록
+        Long startTime = System.currentTimeMillis();
+
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        IntStream.range(0, 50).forEach(i -> {
+            executor.submit(() -> {
+                try {
+                    log.info("좌석 예약 업데이트 요청 - 스레드 : {}", Thread.currentThread().getName());
+
+                    List<Long> seatIdList = new ArrayList<>();
+                    if(i%2 == 0) {
+                        seatIdList.add(seats.get(0));
+                        seatIdList.add(seats.get(1));
+                        seatIdList.add(seats.get(5));
+                        seatIdList.add(seats.get(6));
+                        seatIdList.add(seats.get(7));
+                        seatIdList.add(seats.get(8));
+                    }else {
+                        seatIdList.add(seats.get(1));
+                        seatIdList.add(seats.get(0));
+                        seatIdList.add(seats.get(2));
+                        seatIdList.add(seats.get(3));
+                        seatIdList.add(seats.get(4));
+                    }
+                    userConcertService.reserveSeats(seatIdList, token);
+                    atomicInteger.getAndAdd(1);
+                    log.info("좌석 예약 업데이트 성공 : {}", Thread.currentThread().getName());
+                } catch (Exception e) {
+//                    e.printStackTrace();
+                    log.info("{} - 스레드 : {}", e.getMessage(), Thread.currentThread().getName());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        });
+
+        latch.await();
+
+        // 동시성 테스트 끝 - 결과 기록
+        log.info("[ 동시성 테스트 종료 ]");
+        log.info("성공 케이스 {}건, 총 소요 시간 : {}ms", atomicInteger.get(), System.currentTimeMillis() - startTime);
+
+        executor.shutdown();
+    }
+}

--- a/src/test/java/io/hhplus/concert/concurrency/PaymentConcurrencyTest.java
+++ b/src/test/java/io/hhplus/concert/concurrency/PaymentConcurrencyTest.java
@@ -1,0 +1,90 @@
+package io.hhplus.concert.concurrency;
+
+import io.hhplus.concert.application.payment.UserPaymentFacade;
+import io.hhplus.concert.application.token.UserTokenFacade;
+import io.hhplus.concert.application.user.UserBalanceService;
+import io.hhplus.concert.domain.token.TokenInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+@Slf4j
+public class PaymentConcurrencyTest {
+
+    @Autowired
+    private UserPaymentFacade userPaymentService;
+
+    @Autowired
+    private UserTokenFacade userTokenFacade;
+
+    @Autowired
+    private UserBalanceService userBalanceService;
+
+    @Test
+    @DisplayName("한 유저가 결제 요청을 동시에 하는 경우")
+    public void 결제_동시성_테스트() throws InterruptedException {
+        // 테스트를 위한 데이터 생성
+
+        Long userId = 1L;
+        TokenInfo token = userTokenFacade.issueUserToken(userId);
+
+        // 동시성 테스트 시작 - 시작 시간 기록
+        Long startTime = System.currentTimeMillis();
+
+        CountDownLatch latch = new CountDownLatch(10);
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        AtomicInteger count = new AtomicInteger(0);
+
+        IntStream.range(0, 10).forEach(i -> {
+            executor.submit(() -> {
+                try {
+                    log.info("결제 요청 요청 - 스레드 : {}", Thread.currentThread().getName());
+                    userPaymentService.billing(token.token());
+                    log.info("결제 요청 성공 : {}", Thread.currentThread().getName());
+                    count.getAndAdd(1);
+                } catch (Exception e) {
+                    log.info("{} - 스레드 : {}", e.getMessage(), Thread.currentThread().getName());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        });
+
+        latch.await();
+
+        // 동시성 테스트 끝 - 결과 기록
+        log.info("동시성 테스트 종료 - 성공 횟수 : {},  소요 시간 : {}ms", count, System.currentTimeMillis() - startTime);
+
+        executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("결제 요청과 포인터 충전 요청이 동시에 들어오는 경우")
+    public void 결제_충전_동시성_테스트() throws InterruptedException {
+        // 테스트를 위한 데이터 생성
+        Long userId = 1L;
+        TokenInfo token = userTokenFacade.issueUserToken(userId);
+
+        // 동시성 테스트 시작 - 시작 시간 기록
+        Long startTime = System.currentTimeMillis();
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> userPaymentService.billing(token.token())),
+                CompletableFuture.runAsync(() -> userBalanceService.rechargeBalance(userId, 1000))
+        );
+
+        // 동시성 테스트 끝 - 결과 기록
+        log.info("동시성 테스트 종료 - 소요 시간 : {}ms", System.currentTimeMillis() - startTime);
+        log.info("사용자 잔액 : {}", userBalanceService.findUserBalance(userId));
+    }
+}


### PR DESCRIPTION
석범코치님 안녕하세용 불금입니다!!!
PR 하나하나 봐주시느라 고생하시죠 ㅠㅠ 감사합니다... 
엄청 더운데 식사 챙겨가면서 천천히 봐주세용

<br><br>

-----

## 봐주셨으면 하는 코드
1. 커밋 아이디 : [fdae2c6](https://github.com/vvoohhee/hhplus_3rd_concert/pull/18/commits/fdae2c644ec76e8589b9eb9b81d714c09f9976f9)
동시성 코드가 제대로 작성되었는지 확인 부탁드립니다!
3. 커밋 아이디 : [70763f2](https://github.com/vvoohhee/hhplus_3rd_concert/pull/18/commits/70763f2a45152adece8f5100acb7353ca1e775b2)
콘서트 예약에 비관적 락을 추가하고 서비스마다 @Transactional을 붙이고 파사드에서 보상 트랜잭션을 주는 코드를 구현해 보았습니다.
이렇게 나눈 이유는 우선 좌석에 걸린 락을 너무 오래 잡아두고 싶지 않기 때문이었습니다. 
그러다보니 좌석 상태 변경과 예약 데이터 생성을 별개의 메서드로 나누게 되었는데 혹시 더 좋은 방법이 있을까요..?
보상 트랜잭션을 위해 예약 데이터 생성에 실패하면 좌석 상태를 다시 원상복귀하도록 짰는데요.
catch 안의 보상 트랜잭션까지 실패하는 케이스가 잘 떠오르지 않는데 보상 트랜잭션이 실패할 수 있는 경우에는 어떤 것들이 있을지 궁금합니다!

<br>

## 과제 중에 생긴 질문
1. 아직 작은 사이즈의 시스템이라 생각보다 낙관적 락이 잘 동작하지만, 테스트 케이스가 20개 이상 넘어가면 낙관적 락만으로는 제어가 어려웠습니다. 실무에서 낙관적 락을 사용할 때, 테스트의 크기는 어느정도 잡으면 좋을까요?
2. 비관락을 쓸만한 상황에서는 분산락을 함께 고려해 DB 부하를 줄여보려고 헀습니다. 
그런데 제 경우, 여러 좌석에 예약을 요청하는 기능이 레디스 Pub/Sub 방식을 활용하기에는 키 관리하는 부분이 너무 어렵더라구요. ㅠㅠ...
보고서엔 없지만 좌석 하나 당 하나의 레디스 락을 거는 방식은 한 번 시험삼아 돌려는 봤는데 너무 느렸습니다.
이렇게 여러 row에 대해 락이 필요한 경우에는 분산락을 쓰기 어려운건가요..?