### PR TITLE
Feature/redis queue

### DIFF
--- a/src/main/java/io/hhplus/concert/domain/token/TokenRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenRepository.java
@@ -7,12 +7,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TokenRepository {
-    List<Token> findAll();
-    Optional<Token> findByToken(String token);
-    List<Token> findByStatus(TokenStatusType status);
+    Boolean issueWaitingToken(Token token);
+    void issueActiveTokens(List<Token> tokens);
+    Long findRank(String token);
+    Optional<Token> findWaitingTokenByToken(String token);
+    Optional<Token> findActiveTokenByToken(String token);
+    Integer findActiveTokenCount();
     List<Token> findByStatusAndExpireAtBefore(TokenStatusType status, LocalDateTime expireAt);
-    List<Token> findByStatusAndAvailableAtBefore(TokenStatusType status, LocalDateTime availableAt);
     Optional<Long> findFirstPositionId();
-    Token save(Token token);
-    List<Token> saveAll(List<Token> tokens);
+    List<String> findAvailableWaitingTokens(int count);
+    void deleteActivatedWaitingToken(int count);
 }

--- a/src/main/java/io/hhplus/concert/domain/token/TokenService.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,67 +18,88 @@ public class TokenService {
     private final TokenRepository tokenRepository;
 
     /**
-     * 토큰 발급 메서드
+     * 대기열 토큰 발급 메서드
      *
      * @param userId 유저의 PK
      * @return Token (발급된 토큰)
      */
     @Transactional
-    public Token issue(Long userId) {
+    public Token issueWaitingToken(Long userId) {
         // 토큰의 기본 정보를 생성 후 DB에 저장 (처리시간, 만료시간 제외)
         Token token = new Token(userId);
-        token = tokenRepository.save(token);
-
-        // 현재 대기열 첫 순번인 토큰의 ID 조회
-        Long firstPositionId = tokenRepository.findFirstPositionId().orElseThrow(() -> new CustomException(ErrorCode.NO_DATA));
-
-        // 생성된 사용자 토큰의 대기순번, 처리시간, 만료시간을 설정
-        token.setPosition(token.getId(), firstPositionId);
-        token.setAvailableAtAndExpireAt();
+        Boolean issueResult = tokenRepository.issueWaitingToken(token);
+        if (issueResult == null || !issueResult) throw new CustomException(ErrorCode.REDIS_ERROR);
 
         return token;
     }
 
     /**
-     * 토큰 조회 메서드
+     * 대기열 토큰 조회 메서드
      *
      * @param tokenString 토큰 UUID
      * @return Token
      */
-    public Token find(String tokenString) {
-        Token token = tokenRepository.findByToken(tokenString).orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_EXIST));
+    public Token findWaitingToken(String tokenString) {
+        Long rank = tokenRepository.findRank(tokenString);
 
-        if (token.getStatus().equals(TokenStatusType.EXPIRED)) throw new CustomException(ErrorCode.UNAUTHORIZED);
+        // Rank 조회에는 문제가 없지만, 토큰 값과 일치하는 데이터가 없어 NULL이 내려올 때 예외처리
+        if (rank == null) throw new CustomException(ErrorCode.TOKEN_NOT_EXIST);
 
-        Long first = tokenRepository.findFirstPositionId().orElseThrow(() -> new CustomException(ErrorCode.NO_DATA));
-        token.setPosition(token.getId(), first);
+        Token token = new Token();
+        token.setToken(tokenString);
+        token.setStatus(TokenStatusType.WAITING);
+        token.setPosition(++rank);
 
         return token;
     }
 
     /**
-     * 토큰이 API를 요청할 수 있는 (처리가능한) 상태인지 확인
+     * 토큰으로 ACTIVE 토큰 정보 조회
+     * @param authorization 토큰
+     * @return Token 객체
+     */
+    public Token findActiveToken(String authorization) {
+        return tokenRepository
+                .findActiveTokenByToken(authorization)
+                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_EXIST));
+    }
+
+    /**
+     * 토큰이 API를 요청할 수 있는 (처리가능한) 상태인지 확인하기 위해
+     * ACTIVE 토큰 중에 요청한 토큰과 일치하는 데이터가 있는지 확인
      *
      * @param authorization 토큰
      * @return boolean 가능 여부
      */
     public boolean isAvailable(String authorization) {
-        Token token = tokenRepository.findByToken(authorization).orElseThrow(() ->new CustomException(ErrorCode.TOKEN_NOT_EXIST));
-
-        return token.getStatus().equals(TokenStatusType.AVAILABLE)
-                && token.getAvailableAt().isBefore(LocalDateTime.now())
-                && token.getExpireAt().isAfter(LocalDateTime.now());
+        return tokenRepository
+                .findActiveTokenByToken(authorization)
+                .isPresent();
     }
 
     public void updateLastRequestTime(String authorization) {
-        Token token = tokenRepository.findByToken(authorization).orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_EXIST));
+        Token token = tokenRepository.findWaitingTokenByToken(authorization).orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_EXIST));
         token.updateLastRequestAt(LocalDateTime.now());
     }
 
-    @Transactional
+    /**
+     * 놀이공원 방식으로 대기열 토큰을 관리
+     * ACTIVE로 변경될 수 있는 토큰을 조회해 ACTIVE 토큰을 생성하고, WAITING 토큰은 대기열에서 삭제 처리
+     */
     public void activateToken() {
-        List<Token> tokens = tokenRepository.findByStatusAndAvailableAtBefore(TokenStatusType.WAITING, LocalDateTime.now());
-        tokens.forEach(token -> token.setStatus(TokenStatusType.AVAILABLE));
+        List<String> waitingTokens = tokenRepository.findAvailableWaitingTokens(Token.ACTIVATABLE_COUNT_PER_MIN);
+        Integer activeCount = tokenRepository.findActiveTokenCount();
+
+        if(activeCount > Token.MAX_ACTIVE_LIMIT) return;
+
+        // 토큰 값으로 토큰을 소유한 회원 정보 조회
+        List<Token> tokens = new ArrayList<>();
+        for (String tokenString : waitingTokens) {
+            tokenRepository.findWaitingTokenByToken(tokenString).ifPresent(tokens::add);
+        }
+
+        tokenRepository.issueActiveTokens(tokens);
+        tokenRepository.deleteActivatedWaitingToken(tokens.size());
     }
 
     public void expire() {

--- a/src/main/java/io/hhplus/concert/infrastructure/config/RedisConfig.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package io.hhplus.concert.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableTransactionManagement
+public class RedisConfig {
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setEnableTransactionSupport(true); // 트랜잭션 어노테이션 적용을 위해 필요
+        template.setKeySerializer(new StringRedisSerializer());
+        // template.setValueSerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+
+        return template;
+    }
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/token/TokenRedisRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/token/TokenRedisRepository.java
@@ -1,0 +1,233 @@
+package io.hhplus.concert.infrastructure.token;
+
+import io.hhplus.concert.common.enums.ErrorCode;
+import io.hhplus.concert.common.exception.CustomException;
+import io.hhplus.concert.domain.token.Token;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStringCommands;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.*;
+import org.springframework.data.redis.core.types.Expiration;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Primary
+@RequiredArgsConstructor
+public class TokenRedisRepository {
+
+    private final static String WAITING_QUEUE = "WAITING-QUEUE";
+    private final static String ACTIVE_KEY_PREFIX = "ACTIVE:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private ZSetOperations<String, String> zSetOperations;
+    private ValueOperations<String, String> valueOperations;
+
+    @PostConstruct
+    private void init() {
+        zSetOperations = redisTemplate.opsForZSet();
+        valueOperations = redisTemplate.opsForValue();
+    }
+
+    /**
+     * 대기열에 토큰 저장, token:userId를 key:value로 가지는 redis string 생성
+     *
+     * @param token
+     * @return Token
+     */
+    public Boolean issueWaitingToken(Token token) {
+        long timestamp = System.currentTimeMillis();
+
+        Boolean result = null;
+        try {
+            // 대기열에 토큰 추가, token:userId로 redis string 추가
+            result = zSetOperations.add(WAITING_QUEUE, token.getToken(), timestamp);
+            valueOperations.set(token.getToken(), token.getUserId().toString(), 6, TimeUnit.HOURS);
+            log.info("[토큰 생성][유저 ID : {}] 토큰 생성 요청 - member : {}", token.getUserId(), token.getToken());
+        } catch (Exception e) {
+            log.error("[토큰 생성][유저 ID : {}] 토큰 생성 재시도 요청 중 에러 발생", token.getUserId(), e);
+
+            waitBeforeRetry();
+            try {
+                result = zSetOperations.add(WAITING_QUEUE, token.getToken(), timestamp);
+            } catch (Exception e2) {
+                log.error("[토큰 생성][유저 ID : {}] 토큰 생성 재시도 요청 중 에러 발생", token.getUserId(), e);
+                throw new CustomException(ErrorCode.REDIS_ERROR);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * 대기열 토큰의 현재 순위 조회
+     *
+     * @param token
+     * @return 대기열 토큰의 현재 순위
+     */
+    public Long findRank(String token) {
+        Long rank = null;
+        try {
+            rank = zSetOperations.rank(WAITING_QUEUE, token);
+            log.info("[토큰 순위 조회][토큰 : {}] 순위 : {}", token, rank);
+        } catch (Exception e) {
+            waitBeforeRetry();
+            rank = zSetOperations.rank(WAITING_QUEUE, token);
+        }
+
+        return rank;
+    }
+
+    /**
+     * ACTIVE로 변경할 수 있는 대기열 토큰 리스트 조회
+     *
+     * @param count 최대 변경 가능 개수
+     * @return List<String> 토큰 리스트
+     */
+    public List<String> findAvailableWaitingTokens(int count) {
+        Set<String> range = null;
+        try {
+            range = zSetOperations.range(WAITING_QUEUE, 0, count - 1);
+        } catch (Exception e) {
+            waitBeforeRetry();
+            range = zSetOperations.range(WAITING_QUEUE, 0, count - 1);
+        }
+
+        if (range == null) return List.of();
+
+        return range.stream().toList();
+    }
+
+    /**
+     * 대기열 토큰으로 토큰과 일치하는 토큰+유저 정보 조회
+     *
+     * @param tokenString
+     * @return Optional<Token>
+     */
+    public Optional<Token> findWaitingTokenByToken(String tokenString) {
+        // 대기열에 토큰이 존재하는지 확인
+        Double score = null;
+        try {
+            score = zSetOperations.score(WAITING_QUEUE, tokenString);
+        } catch (Exception e) {
+            waitBeforeRetry();
+            score = zSetOperations.score(WAITING_QUEUE, tokenString);
+        }
+
+        // 대기열에 토큰이 없으면 return Optional.empty()
+        if (score == null) return Optional.empty();
+
+        // 토큰과 일치하는 유저 정보 조회
+        String value = null;
+        try {
+            value = valueOperations.get(tokenString);
+            log.info("[토큰 활성화][토큰 : {}] 유저 ID : {}", tokenString, value);
+        } catch (Exception e) {
+            waitBeforeRetry();
+            value = valueOperations.get(tokenString);
+        }
+
+        // 토큰을 key로 userId를 조회한 결과가 없으면 return Optional.empty()
+        if (value == null) return Optional.empty();
+
+        return Optional.of(new Token(tokenString, Long.parseLong(value)));
+    }
+
+    /**
+     * ACTIVE 토큰 발급
+     * ACTIVE 토큰의 형식 : key:value = "ACTIVE:{token}":"{userId}"
+     *
+     * @param tokens
+     */
+    public void issueActiveTokens(List<Token> tokens) {
+        redisTemplate.executePipelined((RedisCallback<StringRedisConnection>) connection -> {
+            for (Token token : tokens) {
+                String key = ACTIVE_KEY_PREFIX + token.getToken();
+                String value = token.getUserId().toString();
+
+                connection.stringCommands().set(
+                        redisTemplate.getStringSerializer().serialize(key),
+                        redisTemplate.getStringSerializer().serialize(value),
+                        Expiration.from(Token.TTL_MIN, TimeUnit.MINUTES),
+                        RedisStringCommands.SetOption.SET_IF_ABSENT
+                );
+            }
+            return null;
+        });
+
+        log.info("[ACTIVE 토큰 생성] WAITING 토큰 {}개에 대하여 ACTIVE 토큰 생성 요청", tokens.size());
+
+    }
+
+    /**
+     * ACTIVE 토큰으로 토큰 정보를 조회
+     * ACTIVE 토큰의 형식 : key:value = "ACTIVE:{token}":"{userId}"
+     *
+     * @param token ACTIVE 토큰
+     * @return Token 객체
+     */
+    public Optional<Token> findActiveTokenByToken(String token) {
+        String value = null;
+        try {
+            value = valueOperations.get(ACTIVE_KEY_PREFIX + token);
+        } catch (Exception e) { // 레디스 문제로 실패하는 경우 재시도 최대 3번
+            for (int i = 0; i < 3; i++) {
+                value = valueOperations.get(ACTIVE_KEY_PREFIX + token);
+                if (value != null) return Optional.of(new Token(token, Long.parseLong(value)));
+            }
+            return Optional.empty();
+        }
+
+        if (Objects.isNull(value)) return Optional.empty();
+        return Optional.of(new Token(token, Long.parseLong(value)));
+    }
+
+    /**
+     * 현재 ACTIVE 토큰의 개수를 조회
+     *
+     * @return Integer (ACTIVE 토큰의 개수)
+     */
+    public Integer findActiveTokenCount() {
+        Set<String> keys;
+        try {
+            keys = redisTemplate.keys(ACTIVE_KEY_PREFIX + "*");
+        } catch (Exception e) {
+            waitBeforeRetry();
+            keys = redisTemplate.keys(ACTIVE_KEY_PREFIX + "*");
+        }
+
+        return keys == null ? 0 : keys.size();
+    }
+
+    /**
+     * 대기열 토큰 삭제
+     * Rank를 0부터 count개만큼 삭제
+     *
+     * @param count 삭제할 개수
+     */
+    public void deleteWaitingToken(int count) {
+        List<Object> result = redisTemplate.executePipelined((RedisCallback<?>) connection ->
+                connection.zSetCommands().zRemRange(WAITING_QUEUE.getBytes(), 0, count - 1)
+        );
+
+        log.info("[토큰 삭제] ACTIVE로 전환된 WAITING 토큰 {}개 삭제 요청", result.get(0).toString());
+    }
+
+    /**
+     * Retry를 위한 메서드
+     * Redis에서 Exception이 발생하면 100ms 후에 재요청을 할 수 있도록 기다린다.
+     */
+    private void waitBeforeRetry() {
+        try {
+            Thread.sleep(100); // 100ms 대기
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/interfaces/scheduler/TokenScheduler.java
+++ b/src/main/java/io/hhplus/concert/interfaces/scheduler/TokenScheduler.java
@@ -17,7 +17,8 @@ public class TokenScheduler {
         tokenService.activateToken();
     }
 
-    @Scheduled(fixedRate = 3, timeUnit = TimeUnit.MINUTES)
+//     @Scheduled(fixedRate = 3, timeUnit = TimeUnit.MINUTES)
+//     이제 TTL을 설정해 Redis 토큰 만료(삭제) 처리가 이루어지기 때문에 스케줄러 필요 없음
     public void expire() {
         tokenService.expire();
     }


### PR DESCRIPTION
## 대기열 DB -> 레디스 이관을 위해 진행한 설계
**1. 레디스의 어떤 자료구조로 구현할지**
 - 대기열 토큰을 처리하려면 대기자의 순위를 간편하게 확인할 수 있어야 하는데, RANK 명령어를 지원하는 SortedSet 구조가 알맞다고 생각했습니다.
 - 사용자가 토큰 발급을 요청하면 ZSET에 ADD 명령어로 토큰을 추가하고, ZRANK를 통해 순위를 조회하도록 설계했습니다.
 - 기존에는 DB를 이용하여 token과 userId를 한번에 가져올 수 있었는데, 레디스를 사용하는 구조에서는 그것이 어려워졌다는 단점이 있었습니다.

**2. user 정보를 관리하는 방법**
- 기존에는 Token 테이블에 token과 userId를 보관하여 토큰만 있으면 유저 정보를 조회할 수 있었습니다. 
- 생각한 대안으로 ZSET에 넣을 요소의 key를 토큰이 아니라 {token}:{userId} 형태로 넣을까 했지만 매번 폴링 요청이 들어올 때마다 패턴으로 찾는 것이 마음에 들지 않았습니다. 
- key:value 형태로 저장이 되는 Redis String 자료구조와 Redis Hash 중에 무엇을 선택할지 고민했습니다. 
- Redis Hash 자료구조를 사용하는 방식은 ZSET처럼 key 안에 여러 요소가 존재하여 토큰과 유저를 매핑하기 위한 자료임을 보여줄 수 있다는 장점이 있었지만 불필요한 key가 생성된다는 단점이 있었고, 요소 하나하나를 삭제하기에도 Redis String보다는 불편했습니다. 
- 결과적으로 Redis String을 사용해 key에 토큰을, value에 userId를 넣는 방식을 사용하여 액티브 토큰 생성과 대기열 토큰 만료가 완료되면 요소를 삭제하도록 설계했습니다.

**3. ACTIVE 토큰을 관리하는 방법**
- ACTIVE 상태가 되면 더이상 순서는 필요없어지기 때문에 굳이 SortedSet을 사용할 필요가 없었습니다.
- 그래서 Set 자료구조를 사용하기로 했는데, 이것이 액티브 토큰이라는 것을 구분하기 위해 "ACTIVE:*" 패턴으로 구분할 수 있도록 설계했습니다.
- 놀이공원 방식으로 1분에 한 번씩 스케줄러를 돌려 정해진 인원만큼 액티브 토큰으로 변경하도록 하고, 사용자의 토큰 값은 그대로 유지되도록 했습니다. 토큰 값을 key로 user 정보를 가지고 있기 때문입니다.
- 토큰 만료는 TTL로 관리하고, 중간에 이탈하는 사용자에 대해서는 고려하지 않았습니다. 레디스를 이용하면 마지막 요청시간을 보고 만료시키는 방법도 현실적으로 어렵기 때문입니다. 
- 이탈률이 낮은 경우에는 액티브 토큰의 수가 기대와 달리 너무 많아질 수 있어서, ACTIVE 토큰의 최대 개수를 제한하여 한도를 넘으면 스케줄러가 실행되어도 추가적으로 액티브 토큰이 늘어나지 않도록 하는 방어로직을 고려했습니다.

<br><br>

## 봐주셨으면 하는 부분
- Redis Repository가 제대로 구현 되었는지 궁금합니다. 
- 레디스 요청이 실패하면 retry를 얼마나 해야하나 고민이 많았는데 실제로 사용해보니 exception이 나는 경우보다 redis에서 결과를 null로 리턴해주어 문제가 되는 경우가 더 많았습니다. 이런 예외 케이스들은 어떻게 처리하는지 궁금합니다!
- 액티브 토큰을 생성할 때에 저는 (1)액티브토큰생성 (2)대기열토큰삭제 < 이 두 개가 완전히 성공해야 원자성이 보장되는 구조인데요. 레디스는 롤백이 불가능하잖아요...? 레디스로 한 번에 몰아서 요청하는 것은 파이프라인이나 레디스 트랜젝션을 통해 가능하지만, 중간에 예기치 못한 실패가 일어나는 경우에는 원자성을 보장하기가 어렵다는 생각을 했습니다. 이런 경우에는 어떻게 처리하면 될까요? 아무래도 재요청뿐일까요...?