### PR TITLE
STEP-18

### DIFF
--- a/src/main/java/io/hhplus/concert/application/payment/UserPaymentComponent.java
+++ b/src/main/java/io/hhplus/concert/application/payment/UserPaymentComponent.java
@@ -3,6 +3,9 @@ package io.hhplus.concert.application.payment;
 import io.hhplus.concert.domain.concert.dto.SeatPriceInfo;
 import io.hhplus.concert.domain.payment.PaymentService;
 import io.hhplus.concert.domain.payment.Ticket;
+import io.hhplus.concert.domain.payment.dto.PaymentHistoryCommand;
+import io.hhplus.concert.domain.payment.event.PaymentEventPublisher;
+import io.hhplus.concert.domain.payment.event.PaymentSuccessEvent;
 import io.hhplus.concert.domain.user.UserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -17,12 +20,30 @@ public class UserPaymentComponent {
     private final UserService userService;
     private final PaymentService paymentService;
 
+    private final PaymentEventPublisher paymentEventPublisher;
+
     @Transactional
     public List<Ticket> updatePaymentData(Long userId, List<SeatPriceInfo> priceInfos) {
         Integer totalPrice = 0;
         for (SeatPriceInfo seatPriceInfo : priceInfos) totalPrice += seatPriceInfo.price();
 
         userService.consumeBalance(userId, totalPrice);
-        return paymentService.billing(userId, priceInfos);
+        List<Ticket> tickets = paymentService.billing(userId, priceInfos);
+
+        // 히스토리 생성을 위한 Command 리스트 생성
+        List<PaymentHistoryCommand> paymentHistoryCommands =
+                tickets.stream()
+                        .map(PaymentHistoryCommand::fromDomain)
+                        .toList();
+
+        PaymentSuccessEvent event = new PaymentSuccessEvent(paymentHistoryCommands);
+
+        // 아웃박스에 status=init 상태로 insert
+        paymentService.initOutboxMessage(PaymentSuccessEvent.topic, event, event.getIdentifier());
+
+        // 결제 후 티켓 생성 성공하면 결제 성공 이벤트를 발행
+        paymentEventPublisher.success(event);
+
+        return tickets;
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/payment/PaymentHistoryService.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/PaymentHistoryService.java
@@ -1,0 +1,45 @@
+package io.hhplus.concert.domain.payment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert.domain.payment.dto.PaymentHistoryCommand;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentHistoryService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public void savePaymentHistories(List<PaymentHistoryCommand> command) {
+        List<Payment> payments = command
+                .stream()
+                .map(c -> new Payment(c.getTicketId(), c.getPrice(), c.getStatus()))
+                .toList();
+
+        try {
+            paymentRepository.savePayments(payments);
+        } catch (Exception e) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            log.error("[결제API][결제히스토리생성] 결제 정보를 DB에 저장하는 과정에서 알 수 없는 에러 발생");
+            try {
+                // 실패한 데이터를 로그로 확인할 수 있도록 JSON String으로 변경 후 로그에 기록
+                log.error("[결제API][결제히스토리생성] 요청 데이터 : {}", objectMapper.writeValueAsString(payments));
+            } catch (JsonProcessingException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    @Transactional
+    public void deleteAllPaymentHistories() {
+        paymentRepository.deleteAllPaymentHistories();
+    }
+}

--- a/src/main/java/io/hhplus/concert/domain/payment/PaymentOutbox.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/PaymentOutbox.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @Table(name = "payment_outbox")
 @NoArgsConstructor

--- a/src/main/java/io/hhplus/concert/domain/payment/PaymentOutbox.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/PaymentOutbox.java
@@ -1,0 +1,58 @@
+package io.hhplus.concert.domain.payment;
+
+import io.hhplus.concert.common.enums.OutboxStatus;
+import io.hhplus.concert.common.util.ObjectStringConverter;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "payment_outbox")
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentOutbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "topic")
+    private String topic;
+
+    @Column(name = "message")
+    private String message;
+
+    @Column(name = "status")
+    private OutboxStatus status;
+
+    @Column(name = "identifier")
+    private String identifier;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Transient
+    private final int initLimit = 5;
+
+    public PaymentOutbox(String topic, Object message, String identifier) {
+        this.topic = topic;
+        this.status = OutboxStatus.INIT;
+        this.message = ObjectStringConverter.toJson(message);
+        this.identifier = identifier;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isRetryable() {
+        return status == OutboxStatus.INIT && createdAt.isBefore(LocalDateTime.now().minusMinutes(initLimit));
+    }
+
+    public void markAsPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+    }
+}

--- a/src/main/java/io/hhplus/concert/domain/payment/PaymentService.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/PaymentService.java
@@ -43,10 +43,11 @@ public class PaymentService {
     }
 
     @Transactional
-    public void markOutboxAsPublished(String identifier) {
+    public boolean markOutboxAsPublished(String identifier) {
         PaymentOutbox outbox = paymentRepository.findOutboxByIdentifier(identifier);
         if(outbox == null) throw new CustomException(ErrorCode.NO_SUCH_MESSAGE);
 
         outbox.markAsPublished(); // 변경감지 때문에 save() 메서드 요청할 필요 없음
+        return true;
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/payment/PaymentService.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/PaymentService.java
@@ -33,9 +33,9 @@ public class PaymentService {
         return tickets;
     }
 
-    public void initOutboxMessage(String topic, Object message, String identifier) {
+    public PaymentOutbox initOutboxMessage(String topic, Object message, String identifier) {
         PaymentOutbox outbox = new PaymentOutbox(topic, message, identifier);
-        paymentRepository.initOutbox(outbox);
+        return paymentRepository.initOutbox(outbox);
     }
 
     public List<PaymentOutbox> findInitOutboxMessages() {

--- a/src/main/java/io/hhplus/concert/domain/payment/PaymentService.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/PaymentService.java
@@ -1,11 +1,10 @@
 package io.hhplus.concert.domain.payment;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert.common.enums.ErrorCode;
+import io.hhplus.concert.common.enums.OutboxStatus;
+import io.hhplus.concert.common.exception.CustomException;
 import io.hhplus.concert.domain.concert.dto.SeatPriceInfo;
-import io.hhplus.concert.domain.payment.dto.PaymentHistoryCommand;
-import io.hhplus.concert.domain.payment.event.PaymentEventPublisher;
-import io.hhplus.concert.domain.payment.event.PaymentSuccessEvent;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,7 +17,6 @@ import java.util.List;
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
-    private final PaymentEventPublisher paymentEventPublisher;
 
     public List<Ticket> billing(Long userId, List<SeatPriceInfo> priceInfoList) {
         List<Ticket> tickets = priceInfoList
@@ -32,35 +30,23 @@ public class PaymentService {
             log.error("[결제API][유저ID : {}] 티켓 정보를 DB에 저장하는 과정에서 알 수 없는 에러 발생", userId);
         }
 
-        // 결제 후 티켓 생성 성공하면 결제 성공 이벤트를 발행
-        List<PaymentHistoryCommand> events =
-                tickets.stream()
-                        .map(ticket -> new PaymentHistoryCommand(ticket.getId(), ticket.getPrice()))
-                        .toList();
-
-        paymentEventPublisher.success(new PaymentSuccessEvent(events));
-
         return tickets;
     }
 
-    public void savePaymentHistories(List<PaymentHistoryCommand> command) {
+    public void initOutboxMessage(String topic, Object message, String identifier) {
+        PaymentOutbox outbox = new PaymentOutbox(topic, message, identifier);
+        paymentRepository.initOutbox(outbox);
+    }
 
-        List<Payment> payments = command
-                .stream()
-                .map(c -> new Payment(c.getTicketId(), c.getPrice(), c.getStatus()))
-                .toList();
+    public List<PaymentOutbox> findInitOutboxMessages() {
+        return paymentRepository.findOutboxesByStatus(OutboxStatus.INIT);
+    }
 
-        try {
-            paymentRepository.savePayments(payments);
-        } catch (Exception e) {
-            ObjectMapper objectMapper = new ObjectMapper();
-            log.error("[결제API][결제히스토리생성] 결제 정보를 DB에 저장하는 과정에서 알 수 없는 에러 발생");
-            try {
-                // 실패한 데이터를 로그로 확인할 수 있도록 JSON String으로 변경 후 로그에 기록
-                log.error("[결제API][결제히스토리생성] 요청 데이터 : {}", objectMapper.writeValueAsString(payments));
-            } catch (JsonProcessingException ex) {
-                throw new RuntimeException(ex);
-            }
-        }
+    @Transactional
+    public void markOutboxAsPublished(String identifier) {
+        PaymentOutbox outbox = paymentRepository.findOutboxByIdentifier(identifier);
+        if(outbox == null) throw new CustomException(ErrorCode.NO_SUCH_MESSAGE);
+
+        outbox.markAsPublished(); // 변경감지 때문에 save() 메서드 요청할 필요 없음
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/payment/event/PaymentSuccessEvent.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/event/PaymentSuccessEvent.java
@@ -1,15 +1,21 @@
 package io.hhplus.concert.domain.payment.event;
 
 import io.hhplus.concert.domain.payment.dto.PaymentHistoryCommand;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class PaymentSuccessEvent {
+    public static final String topic = "payment-success";
     private List<PaymentHistoryCommand> paymentHistoryCommands;
+    private String identifier; // 각각의 메시지를 구분하기 위한 uuid를 추가
 
     public PaymentSuccessEvent(List<PaymentHistoryCommand> paymentHistoryCommands) {
         this.paymentHistoryCommands = paymentHistoryCommands;
+        this.identifier = UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/payment/event/spring/PaymentSpringEventListener.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/event/spring/PaymentSpringEventListener.java
@@ -1,0 +1,25 @@
+package io.hhplus.concert.domain.payment.event.spring;
+
+import io.hhplus.concert.domain.payment.PaymentHistoryService;
+import io.hhplus.concert.domain.payment.event.PaymentEventListener;
+import io.hhplus.concert.domain.payment.event.PaymentSuccessEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class PaymentSpringEventListener implements PaymentEventListener {
+    private final PaymentHistoryService paymentHistoryService;
+
+    public PaymentSpringEventListener(PaymentHistoryService paymentHistoryService) {
+        this.paymentHistoryService = paymentHistoryService;
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Override
+    public void paymentSuccessHandler(PaymentSuccessEvent event) {
+        paymentHistoryService.savePaymentHistories(event.getPaymentHistoryCommands());
+    }
+}

--- a/src/main/java/io/hhplus/concert/domain/payment/event/spring/PaymentSpringEventPublisher.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/event/spring/PaymentSpringEventPublisher.java
@@ -1,0 +1,20 @@
+package io.hhplus.concert.domain.payment.event.spring;
+
+import io.hhplus.concert.domain.payment.event.PaymentEventPublisher;
+import io.hhplus.concert.domain.payment.event.PaymentSuccessEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentSpringEventPublisher implements PaymentEventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public PaymentSpringEventPublisher(ApplicationEventPublisher paymentKafkaMessageProducer) {
+        this.applicationEventPublisher = paymentKafkaMessageProducer;
+    }
+
+    @Override
+    public void success(PaymentSuccessEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/io/hhplus/concert/interfaces/scheduler/PaymentOutboxScheduler.java
+++ b/src/main/java/io/hhplus/concert/interfaces/scheduler/PaymentOutboxScheduler.java
@@ -1,0 +1,18 @@
+package io.hhplus.concert.interfaces.scheduler;
+
+import io.hhplus.concert.application.payment.UserPaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+public class PaymentOutboxScheduler {
+
+    private final UserPaymentService userPaymentService;
+
+    @Scheduled(fixedRate = 5, timeUnit = TimeUnit.MINUTES)
+    public void retryInitMessages() {
+        userPaymentService.retryInitMessages();
+    }
+}

--- a/src/main/java/io/hhplus/concert/interfaces/scheduler/PaymentOutboxScheduler.java
+++ b/src/main/java/io/hhplus/concert/interfaces/scheduler/PaymentOutboxScheduler.java
@@ -3,9 +3,11 @@ package io.hhplus.concert.interfaces.scheduler;
 import io.hhplus.concert.application.payment.UserPaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
+@Component
 @RequiredArgsConstructor
 public class PaymentOutboxScheduler {
 

--- a/src/test/java/io/hhplus/concert/domain/payment/PaymentUnitTest.java
+++ b/src/test/java/io/hhplus/concert/domain/payment/PaymentUnitTest.java
@@ -1,13 +1,29 @@
 package io.hhplus.concert.domain.payment;
 
+import io.hhplus.concert.common.enums.OutboxStatus;
+import io.hhplus.concert.domain.payment.dto.PaymentHistoryCommand;
+import io.hhplus.concert.domain.payment.event.PaymentSuccessEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class PaymentUnitTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private PaymentService paymentService;
 
     @Test
     void TicketCreationTest_성공() {
@@ -43,4 +59,50 @@ public class PaymentUnitTest {
         assertThrows(IllegalArgumentException.class, () -> new Ticket(validSeatId, invalidUserId, validPrice));
     }
 
+    @Test
+    void PaymentOutbox_INIT_데이터생성_성공() {
+        // given
+        List<PaymentHistoryCommand> commands = List.of(
+                new PaymentHistoryCommand(1L, 1000),
+                new PaymentHistoryCommand(2L, 2000)
+        );
+        PaymentSuccessEvent event = new PaymentSuccessEvent(commands);
+
+        // when
+        when(paymentRepository.initOutbox(any(PaymentOutbox.class)))
+                .thenAnswer(invocation -> {
+                    PaymentOutbox argument = invocation.getArgument(0);
+                    return new PaymentOutbox(
+                            1L,
+                            argument.getTopic(),
+                            argument.getMessage(),
+                            OutboxStatus.INIT,
+                            argument.getIdentifier(),
+                            LocalDateTime.now());
+                });
+
+        PaymentOutbox result = paymentService.initOutboxMessage(PaymentSuccessEvent.topic, event, event.getIdentifier());
+
+        // then
+        assertEquals(event.getIdentifier(), result.getIdentifier());
+        assertEquals(PaymentSuccessEvent.topic, result.getTopic());
+        assertEquals(OutboxStatus.INIT, result.getStatus());
+    }
+
+    @Test
+    void PaymentOutbox_Published_상태로_데아터_변경_성공() {
+        // given
+        List<PaymentHistoryCommand> commands = List.of(
+                new PaymentHistoryCommand(5L, 10000)
+        );
+        PaymentSuccessEvent event = new PaymentSuccessEvent(commands);
+        PaymentOutbox outbox = new PaymentOutbox(PaymentSuccessEvent.topic, event, event.getIdentifier());
+
+        // when
+        when(paymentRepository.findOutboxByIdentifier(event.getIdentifier())).thenReturn(outbox);
+        boolean result = paymentService.markOutboxAsPublished(event.getIdentifier());
+
+        // then
+        assertTrue(result);
+    }
 }


### PR DESCRIPTION
### 리뷰해주셨으면 하는 내용
1. 기존 애플리케이션 이벤트를 카프카 메시지로 변경하면서 EventPublisher 인터페이스를 스프링 이벤트 발행 클래스, 카프카 메시지 발행 클래스가 각각 구현하도록 했는데 의도대로 잘 구현되었는지 궁금합니다!
2. 스케줄러로 5분 이상 init 상태인 메시지를 조회하는 방법이 적절한지 궁금합니당. 
  파사드의 `retryInitMessagesstatus` 메서드에서 outbox를 조회하는 과정에서, `status`가 카디널리티는 작지만 데이터를 걸러내기에 유의미하다고 생각해서 status에 인덱스를 걸었습니다. 
  날짜로 범위 조건을 걸어 조회를 하는 것은 성능이 느릴 것 같아서 코드 단에서 filter로 걸러내도록 했는데요. 
  이렇게 인덱스를 거는 방법이 적절한지, 그리고 날짜 범위도 디비에서 걸러서 조회하는 것이 나은지 궁금합니다!
3. `PaymentOutbox`는 결제 도메인의 카프카 메시지를 위한 outbox 테이블로 설계를 해보았습니다. 
  지금은 메시지가 하나밖에 없어서 retry 하는 로직에서 if문으로 토픽을 검사하는데요. 
  메시지가 많아지면 보통 어떤 방식으로 retry를 하는지 궁금합니다! 

<br><br>


* Outbox 관련한 통합 테스트(outbox에 상태를 init으로 생성, consume 후의 상태 변경 테스트)는 `STEP-17`에 발행/컨슘 통합테스트에서 함께 진행했습니다. 감사합니다!